### PR TITLE
[Bug]: アプリが頻繁に落ちてしまう

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,6 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-keep class com.unity3d.player.** { *; }
+-keepclassmembers class com.example.withmo.MainActivity { *; }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,8 @@
         <activity
             android:name=".MainActivity"
             android:screenOrientation="portrait"
+            android:launchMode="singleTop"
+            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|uiMode"
             android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.Withmo">

--- a/app/src/main/java/com/example/withmo/MainActivity.kt
+++ b/app/src/main/java/com/example/withmo/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.example.withmo
 
+import android.appwidget.AppWidgetHost
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -53,6 +54,9 @@ class MainActivity : ComponentActivity() {
 
     @Inject
     lateinit var appInfoRepository: AppInfoRepository
+
+    @Inject
+    lateinit var appWidgetHost: AppWidgetHost
 
     private val packageReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
@@ -172,12 +176,17 @@ class MainActivity : ComponentActivity() {
 
     override fun onResume() {
         super.onResume()
-        unityPlayer?.resume()
+        unityPlayer?.onResume()
     }
 
     override fun onPause() {
         super.onPause()
-        unityPlayer?.pause()
+        unityPlayer?.onPause()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        appWidgetHost.stopListening()
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
## 概要
withmoをバックグラウンドからフォアグラウンドに戻した際に、アプリのクラッシュが多発していたため対応。
しかし、完全にクラッシュをなくすことは不可能っぽく、完全に落ちないようにできたわけではない。（システムの仕様上、不要なバックグラウンドのアプリは強制的に終了させてしまうらしい...）
今後の変更で落ちても大丈夫なように、すべての設定値（表示するモデルなど）も端末内に保存するのが良さそう。

## 実施Issue
#107 

<!-- 以下は、条件に当てはまった際に使用 -->
<!-- バグの修正の際にのみ使用 -->
## 原因と対処
widgetHostにライフサイクルを合わせるのが出来ていなかったため、アプリのクラッシュが多発していた。
