### PR TITLE
[Improvement]: Widget編集モードへの移行方法の変更 

### DIFF
--- a/app/src/main/java/com/example/withmo/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/withmo/ui/screens/home/HomeScreen.kt
@@ -10,15 +10,10 @@ import android.view.View
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.safeGestures
@@ -33,7 +28,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -44,7 +38,6 @@ import com.example.withmo.domain.model.AppInfo
 import com.example.withmo.domain.model.WidgetInfo
 import com.example.withmo.domain.model.user_settings.SortType
 import com.example.withmo.domain.model.user_settings.toShape
-import com.example.withmo.ui.component.BodyMediumText
 import com.example.withmo.ui.theme.BottomSheetShape
 import com.example.withmo.ui.theme.UiConfig
 import kotlinx.collections.immutable.ImmutableList
@@ -67,7 +60,6 @@ fun HomeScreen(
 
     val scope = rememberCoroutineScope()
     val appListSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    val actionSelectionSheetState = rememberModalBottomSheetState()
     val widgetListSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     val appList by viewModel.appList.collectAsStateWithLifecycle()
@@ -166,23 +158,6 @@ fun HomeScreen(
                     }
                 }
 
-                is HomeUiEvent.OpenActionSelectionBottomSheet -> {
-                    scope.launch {
-                        viewModel.changeIsActionSelectionBottomSheetOpened(true)
-                        actionSelectionSheetState.show()
-                    }
-                }
-
-                is HomeUiEvent.HideActionSelectionBottomSheet -> {
-                    scope.launch {
-                        actionSelectionSheetState.hide()
-                    }.invokeOnCompletion {
-                        if (!actionSelectionSheetState.isVisible) {
-                            viewModel.changeIsActionSelectionBottomSheetOpened(false)
-                        }
-                    }
-                }
-
                 is HomeUiEvent.OpenWidgetListBottomSheet -> {
                     scope.launch {
                         viewModel.changeIsWidgetListBottomSheetOpened(true)
@@ -234,7 +209,6 @@ fun HomeScreen(
         onEvent = viewModel::onEvent,
         homeAppList = homeAppList,
         appListSheetState = appListSheetState,
-        actionSelectionSheetState = actionSelectionSheetState,
         widgetListSheetState = widgetListSheetState,
         widgetInfoList = viewModel.getWidgetInfoList(),
         createWidgetView = viewModel::createWidgetView,
@@ -250,7 +224,6 @@ private fun HomeScreen(
     onEvent: (HomeUiEvent) -> Unit,
     homeAppList: ImmutableList<AppInfo>,
     appListSheetState: SheetState,
-    actionSelectionSheetState: SheetState,
     widgetListSheetState: SheetState,
     widgetInfoList: ImmutableList<AppWidgetProviderInfo>,
     createWidgetView: (Context, WidgetInfo, Int, Int) -> View,
@@ -295,24 +268,6 @@ private fun HomeScreen(
         }
     }
 
-    if (uiState.isActionSelectionBottomSheetOpened) {
-        ModalBottomSheet(
-            onDismissRequest = { onEvent(HomeUiEvent.HideActionSelectionBottomSheet) },
-            sheetState = actionSelectionSheetState,
-        ) {
-            HomeScreenActionPicker(
-                addWidget = {
-                    onEvent(HomeUiEvent.OpenWidgetListBottomSheet)
-                    onEvent(HomeUiEvent.HideActionSelectionBottomSheet)
-                },
-                enterExitMode = {
-                    onEvent(HomeUiEvent.EnterEditMode)
-                    onEvent(HomeUiEvent.HideActionSelectionBottomSheet)
-                },
-            )
-        }
-    }
-
     Box(
         modifier = modifier
             .padding(
@@ -325,49 +280,6 @@ private fun HomeScreen(
             onEvent = onEvent,
             createWidgetView = createWidgetView,
             modifier = Modifier.fillMaxSize(),
-        )
-    }
-}
-
-@Composable
-private fun HomeScreenActionPicker(
-    addWidget: () -> Unit,
-    enterExitMode: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Column(
-        modifier = modifier
-            .padding(horizontal = UiConfig.MediumPadding),
-    ) {
-        HomeScreenActionPickerItem(
-            title = "Widgetを追加する",
-            action = addWidget,
-            modifier = Modifier.fillMaxWidth(),
-        )
-        HomeScreenActionPickerItem(
-            title = "編集する",
-            action = enterExitMode,
-            modifier = Modifier.fillMaxWidth(),
-        )
-    }
-}
-
-@Composable
-private fun HomeScreenActionPickerItem(
-    title: String,
-    action: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Row(
-        modifier = modifier
-            .height(UiConfig.SettingItemHeight)
-            .clickable { action() }
-            .padding(horizontal = UiConfig.MediumPadding),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        BodyMediumText(
-            text = title,
-            modifier = Modifier.fillMaxWidth(),
         )
     }
 }

--- a/app/src/main/java/com/example/withmo/ui/screens/home/HomeUiEvent.kt
+++ b/app/src/main/java/com/example/withmo/ui/screens/home/HomeUiEvent.kt
@@ -12,8 +12,6 @@ sealed interface HomeUiEvent : UiEvent {
     data class OnValueChangeAppSearchQuery(val query: String) : HomeUiEvent
     data object OpenAppListBottomSheet : HomeUiEvent
     data object HideAppListBottomSheet : HomeUiEvent
-    data object OpenActionSelectionBottomSheet : HomeUiEvent
-    data object HideActionSelectionBottomSheet : HomeUiEvent
     data object OpenWidgetListBottomSheet : HomeUiEvent
     data object HideWidgetListBottomSheet : HomeUiEvent
     data class OnSelectWidget(val widgetInfo: AppWidgetProviderInfo) : HomeUiEvent

--- a/app/src/main/java/com/example/withmo/ui/screens/home/HomeUiState.kt
+++ b/app/src/main/java/com/example/withmo/ui/screens/home/HomeUiState.kt
@@ -16,7 +16,6 @@ data class HomeUiState(
     val currentTime: DateTimeInfo = DateTimeInfo(),
     val isShowScaleSlider: Boolean = false,
     val isAppListBottomSheetOpened: Boolean = false,
-    val isActionSelectionBottomSheetOpened: Boolean = false,
     val isWidgetListBottomSheetOpened: Boolean = false,
     val displayedWidgetList: ImmutableList<WidgetInfo> = persistentListOf(),
     val pendingWidgetId: Int = 0,

--- a/app/src/main/java/com/example/withmo/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/withmo/ui/screens/home/HomeViewModel.kt
@@ -119,12 +119,6 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun changeIsActionSelectionBottomSheetOpened(isActionSelectionBottomSheetOpened: Boolean) {
-        _uiState.update {
-            it.copy(isActionSelectionBottomSheetOpened = isActionSelectionBottomSheetOpened)
-        }
-    }
-
     fun changeIsWidgetListBottomSheetOpened(isWidgetListBottomSheetOpened: Boolean) {
         _uiState.update {
             it.copy(isWidgetListBottomSheetOpened = isWidgetListBottomSheetOpened)

--- a/app/src/main/java/com/example/withmo/ui/screens/home/PagerContent.kt
+++ b/app/src/main/java/com/example/withmo/ui/screens/home/PagerContent.kt
@@ -122,7 +122,7 @@ fun PagerContent(
                             .pointerInput(Unit) {
                                 detectTapGestures(
                                     onLongPress = {
-                                        onEvent(HomeUiEvent.OpenActionSelectionBottomSheet)
+                                        onEvent(HomeUiEvent.EnterEditMode)
                                     },
                                 )
                             },
@@ -137,6 +137,9 @@ fun PagerContent(
             exitEditMode = {
                 onEvent(HomeUiEvent.ExitEditMode)
             },
+            openWidgetList = {
+                onEvent(HomeUiEvent.OpenWidgetListBottomSheet)
+            },
             modifier = Modifier.fillMaxWidth(),
         )
     }
@@ -148,6 +151,7 @@ private fun PageIndicator(
     currentPage: Int,
     isEditMode: Boolean,
     exitEditMode: () -> Unit,
+    openWidgetList: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -158,8 +162,20 @@ private fun PageIndicator(
     ) {
         if (isEditMode) {
             LabelMediumText(
+                text = "＋",
+                modifier = Modifier
+                    .padding(horizontal = UiConfig.MediumPadding)
+                    .background(
+                        MaterialTheme.colorScheme.surface,
+                        CircleShape,
+                    )
+                    .clickable { openWidgetList() }
+                    .padding(horizontal = UiConfig.MediumPadding),
+            )
+            LabelMediumText(
                 text = "編集完了",
                 modifier = Modifier
+                    .padding(horizontal = UiConfig.MediumPadding)
                     .background(
                         MaterialTheme.colorScheme.surface,
                         CircleShape,


### PR DESCRIPTION
## 概要
これまでのWidget追加方法（ページ2で長押し→編集モードにするかWidget追加するか選ぶ→Widget追加する→好きな位置に動かすためにまた長押しして編集モードにするかどうか選ばなきゃならない）だと何度も長押ししなくてはならず非常に使いづらかったため、ページ2で長押し→編集モード（Widgetの追加が出来るボタンを追加）→Widgetの追加が出来るようにした。

## 実施Issue
#110

<!-- UIに変更があった際に使用 -->
## UI変更
| Before | After |
|-------|-------|
| <img src="https://github.com/user-attachments/assets/abdec70e-3c8b-4cad-a369-b50fb8417a43" width="300" /> | <img src="https://github.com/user-attachments/assets/3b72e5b4-c0f1-4517-b8d7-dc3a52dcda05" width="300" /> |