### PR TITLE
Widget一覧画面のUI改善

### DIFF
--- a/app/src/main/java/com/example/withmo/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/withmo/ui/screens/home/HomeScreen.kt
@@ -41,6 +41,7 @@ import com.example.withmo.domain.model.user_settings.toShape
 import com.example.withmo.ui.theme.BottomSheetShape
 import com.example.withmo.ui.theme.UiConfig
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -211,7 +212,7 @@ fun HomeScreen(
         homeAppList = homeAppList,
         appListSheetState = appListSheetState,
         widgetListSheetState = widgetListSheetState,
-        widgetInfoList = viewModel.getWidgetInfoList(),
+        groupedWidgetInfoMap = viewModel.getGroupedWidgetInfoMap(),
         createWidgetView = viewModel::createWidgetView,
         modifier = Modifier.fillMaxSize(),
     )
@@ -226,7 +227,7 @@ private fun HomeScreen(
     homeAppList: ImmutableList<AppInfo>,
     appListSheetState: SheetState,
     widgetListSheetState: SheetState,
-    widgetInfoList: ImmutableList<AppWidgetProviderInfo>,
+    groupedWidgetInfoMap: ImmutableMap<String, List<AppWidgetProviderInfo>>,
     createWidgetView: (Context, WidgetInfo, Int, Int) -> View,
     modifier: Modifier = Modifier,
 ) {
@@ -263,7 +264,7 @@ private fun HomeScreen(
             ),
         ) {
             WidgetList(
-                widgetInfoList = widgetInfoList,
+                groupedWidgetInfoMap = groupedWidgetInfoMap,
                 selectWidget = { onEvent(HomeUiEvent.OnSelectWidget(it)) },
             )
         }

--- a/app/src/main/java/com/example/withmo/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/withmo/ui/screens/home/HomeViewModel.kt
@@ -22,8 +22,9 @@ import com.example.withmo.domain.repository.WidgetInfoRepository
 import com.example.withmo.domain.usecase.user_settings.GetUserSettingsUseCase
 import com.example.withmo.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -137,8 +138,11 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun getWidgetInfoList(): ImmutableList<AppWidgetProviderInfo> {
-        return appWidgetManager.installedProviders.toPersistentList()
+    fun getGroupedWidgetInfoMap(): ImmutableMap<String, List<AppWidgetProviderInfo>> {
+        return appWidgetManager
+            .installedProviders
+            .groupBy { it.provider.packageName }
+            .toPersistentMap()
     }
 
     fun selectWidget(

--- a/app/src/main/java/com/example/withmo/ui/screens/home/WidgetList.kt
+++ b/app/src/main/java/com/example/withmo/ui/screens/home/WidgetList.kt
@@ -3,93 +3,191 @@ package com.example.withmo.ui.screens.home
 import android.appwidget.AppWidgetProviderInfo
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ExpandLess
+import androidx.compose.material.icons.rounded.ExpandMore
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
+import com.example.withmo.ui.component.BodyMediumText
+import com.example.withmo.ui.component.LabelMediumText
+import com.example.withmo.ui.theme.UiConfig
 import com.example.withmo.utils.WidgetUtils
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.toPersistentList
 
 @RequiresApi(Build.VERSION_CODES.S)
 @Composable
 fun WidgetList(
+    groupedWidgetInfoMap: ImmutableMap<String, List<AppWidgetProviderInfo>>,
+    selectWidget: (AppWidgetProviderInfo) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(UiConfig.MediumPadding),
+        contentPadding = PaddingValues(UiConfig.MediumPadding),
+    ) {
+        groupedWidgetInfoMap.forEach { (packageName, widgetInfoList) ->
+            item {
+                WidgetContainer(
+                    packageName = packageName,
+                    widgetInfoList = widgetInfoList.toPersistentList(),
+                    selectWidget = selectWidget,
+                )
+            }
+        }
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.S)
+@Suppress("LongMethod")
+@Composable
+fun WidgetContainer(
+    packageName: String,
     widgetInfoList: ImmutableList<AppWidgetProviderInfo>,
     selectWidget: (AppWidgetProviderInfo) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
 
-    LazyColumn(
-        modifier = modifier,
-    ) {
-        items(widgetInfoList) { widgetInfo ->
-            val appIconDrawable = remember { WidgetUtils.loadAppIcon(context, widgetInfo.provider.packageName) }
-            val widgetLabel = widgetInfo.loadLabel(context.packageManager) ?: "Unknown Widget"
-            val widgetDescription = widgetInfo.loadDescription(context) ?: "Unknown Widget"
-            val previewDrawable = remember { WidgetUtils.loadWidgetPreviewImage(context, widgetInfo) }
-            val previewLayout = remember { WidgetUtils.loadWidgetPreviewLayout(context, widgetInfo) }
+    val appIcon = remember { WidgetUtils.loadAppIcon(context, packageName) }
+    val appLabel = remember { WidgetUtils.loadAppLabel(context, packageName) }
 
+    var expanded by remember { mutableStateOf(false) }
+
+    Surface(
+        modifier = modifier.animateContentSize(),
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.surfaceContainer,
+    ) {
+        Column {
             Row(
                 modifier = Modifier
+                    .height(UiConfig.SettingItemHeight)
                     .fillMaxWidth()
-                    .clickable {
-                        selectWidget(widgetInfo)
-                    }
-                    .padding(8.dp),
+                    .clickable { expanded = !expanded }
+                    .padding(horizontal = UiConfig.MediumPadding),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                if (previewDrawable != null) {
+                appIcon?.let {
                     Image(
-                        painter = rememberDrawablePainter(drawable = previewDrawable),
+                        painter = rememberDrawablePainter(drawable = appIcon),
                         contentDescription = null,
-                        modifier = Modifier.size(64.dp),
+                        modifier = Modifier.size(UiConfig.SettingsScreenItemIconSize),
                     )
-                } else {
-                    previewLayout?.asImageBitmap()?.let {
-                        Image(
-                            bitmap = it,
-                            contentDescription = null,
-                            modifier = Modifier.size(64.dp),
+                }
+                Spacer(
+                    modifier = Modifier.width(UiConfig.ExtraSmallPadding),
+                )
+                appLabel?.let {
+                    BodyMediumText(
+                        text = appLabel,
+                        modifier = Modifier.weight(UiConfig.DefaultWeight),
+                    )
+                }
+                Icon(
+                    imageVector = if (expanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore,
+                    contentDescription = if (expanded) "Close" else "Open",
+                    tint = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+
+            if (expanded) {
+                Column(
+                    modifier = Modifier
+                        .padding(UiConfig.MediumPadding)
+                        .align(Alignment.CenterHorizontally),
+                    verticalArrangement = Arrangement.spacedBy(UiConfig.MediumPadding),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    widgetInfoList.forEach { widgetInfo ->
+                        WidgetItem(
+                            widgetInfo = widgetInfo,
+                            selectWidget = selectWidget,
+                            modifier = Modifier.fillMaxWidth(),
                         )
                     }
                 }
-
-                Spacer(modifier = Modifier.width(8.dp))
-
-                Column {
-                    Text(text = widgetLabel, fontWeight = FontWeight.Bold)
-
-                    // Display app icon and package name
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        if (appIconDrawable != null) {
-                            Image(
-                                painter = rememberDrawablePainter(drawable = appIconDrawable),
-                                contentDescription = null,
-                                modifier = Modifier.size(24.dp),
-                            )
-                        }
-                        Spacer(modifier = Modifier.width(4.dp))
-                        Text(text = widgetDescription.toString())
-                    }
-                }
             }
+        }
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.S)
+@Composable
+fun WidgetItem(
+    widgetInfo: AppWidgetProviderInfo,
+    selectWidget: (AppWidgetProviderInfo) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+
+    val widgetLabel = widgetInfo.loadLabel(context.packageManager)
+    val widgetDescription = widgetInfo.loadDescription(context)
+    val previewDrawable = remember { WidgetUtils.loadWidgetPreviewImage(context, widgetInfo) }
+    val previewLayout = remember { WidgetUtils.loadWidgetPreviewLayout(context, widgetInfo) }
+
+    Column(
+        modifier = modifier
+            .clickable { selectWidget(widgetInfo) },
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        if (previewDrawable != null) {
+            Image(
+                painter = rememberDrawablePainter(drawable = previewDrawable),
+                contentDescription = null,
+                modifier = Modifier
+                    .sizeIn(maxWidth = UiConfig.WidgetPreviewSize, maxHeight = UiConfig.WidgetPreviewSize),
+            )
+        } else {
+            previewLayout?.asImageBitmap()?.let {
+                Image(
+                    bitmap = it,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .sizeIn(maxWidth = UiConfig.WidgetPreviewSize, maxHeight = UiConfig.WidgetPreviewSize),
+                )
+            }
+        }
+        Spacer(
+            modifier = Modifier.height(UiConfig.TinyPadding),
+        )
+        widgetLabel?.let {
+            BodyMediumText(text = it)
+        }
+        widgetDescription?.let {
+            LabelMediumText(
+                text = it.toString(),
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = UiConfig.DisabledContentAlpha),
+                maxLines = UiConfig.WidgetDescriptionMaxLines,
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/withmo/ui/theme/UiConfig.kt
+++ b/app/src/main/java/com/example/withmo/ui/theme/UiConfig.kt
@@ -34,6 +34,8 @@ data object UiConfig {
 
     const val FavoriteAppListMaxSize = 4
 
+    const val WidgetDescriptionMaxLines = 3
+
 //    App Icon Settings
     val AppIconPreviewHeight = 200.dp
 
@@ -70,4 +72,6 @@ data object UiConfig {
     val PageIndicatorSize = 8.dp
 
     val OnboardingImageSize = 250.dp
+
+    val WidgetPreviewSize = 150.dp
 }

--- a/app/src/main/java/com/example/withmo/utils/WidgetUtils.kt
+++ b/app/src/main/java/com/example/withmo/utils/WidgetUtils.kt
@@ -74,6 +74,16 @@ object WidgetUtils {
         }
     }
 
+    fun loadAppLabel(context: Context, packageName: String): String? {
+        return try {
+            val applicationInfo = context.packageManager.getApplicationInfo(packageName, 0)
+            context.packageManager.getApplicationLabel(applicationInfo).toString()
+        } catch (e: Exception) {
+            Log.e("loadAppName", "Failed to load app name", e)
+            null
+        }
+    }
+
     private const val PreviewImageSize = 500
     private const val PackageContextFlags = Context.CONTEXT_IGNORE_SECURITY or Context.CONTEXT_INCLUDE_CODE
 }


### PR DESCRIPTION
## 概要
アプリごとにWidgetをまとめ表示するように変更した。これにより、どのアプリのWidgetなのかがわかるようになりWidgetを追加しやすくなったと考えられる。また、Previewのサイズを大きくしどのようなWidgetなのかわかりやすいようにした。

## 実施Issue
#83 

<!-- UIに変更があった際に使用 -->
## UI変更
| Before | After |
|-------|-------|
| <img src="https://github.com/user-attachments/assets/37a3f8cb-b76a-4826-8de4-7e06e27aa0a3" width="300" /> | <img src="https://github.com/user-attachments/assets/9224a29d-2f1d-4209-ba4b-2494f6bfbe09" width="300" /> |
