### PR TITLE
[Bug]: AppUtils.getAppIconでクラッシュが発生し、アプリが起動できないバグの修正

### DIFF
--- a/core/util/src/main/kotlin/io/github/kei_1111/withmo/core/util/AppUtils.kt
+++ b/core/util/src/main/kotlin/io/github/kei_1111/withmo/core/util/AppUtils.kt
@@ -76,10 +76,14 @@ object AppUtils {
 
     @RequiresApi(Build.VERSION_CODES.O)
     private fun getAppIcon(icon: Drawable): AppIcon {
-        return if (icon is AdaptiveIconDrawable) {
+        val adaptive = icon as? AdaptiveIconDrawable
+        val foregroundIcon: Drawable? = adaptive?.foreground
+        val backgroundIcon: Drawable? = adaptive?.background
+
+        return if (foregroundIcon != null) {
             AppIcon(
-                foregroundIcon = icon.foreground,
-                backgroundIcon = icon.background,
+                foregroundIcon = foregroundIcon,
+                backgroundIcon = backgroundIcon,
             )
         } else {
             AppIcon(

--- a/core/util/src/main/kotlin/io/github/kei_1111/withmo/core/util/AppUtils.kt
+++ b/core/util/src/main/kotlin/io/github/kei_1111/withmo/core/util/AppUtils.kt
@@ -74,6 +74,29 @@ object AppUtils {
         }
     }
 
+    /**
+     * 与えられた [Drawable] からアプリ用アイコンを組み立てて返す。
+     *
+     * ### 背景
+     * - Android 8.0 (API 26) 以降は “Adaptive Icon” が導入され、
+     *   `Drawable` が `AdaptiveIconDrawable` の場合は
+     *   **foreground / background** の 2 レイヤーを持つ。
+     * - しかし端末メーカー独自のアイコンパックや旧形式の APK を
+     *   OS がラップしたケースでは、`foreground` / `background` の
+     *   どちらか一方、または両方が **null** になることがある。
+     * - Kotlin ではプラットフォーム型 (`Drawable!`) を非 null として
+     *   受け取ると自動挿入された null チェックで
+     *   `NullPointerException` が発生するため、ここで安全に判定している。
+     *
+     * ### 振る舞い
+     * 1. `AdaptiveIconDrawable` なら各レイヤーを取得。
+     * 2. **foreground が null でなければ** 2 レイヤー構成として返す。
+     * 3. foreground が null（＝実質レガシーアイコン）なら
+     *    元の `Drawable` を 1 枚絵としてフォールバック。
+     *
+     * @param icon アプリから取得したアイコン `Drawable`
+     * @return [AppIcon] - 分離された 2 レイヤー、またはレガシー 1 レイヤー
+     */
     @RequiresApi(Build.VERSION_CODES.O)
     private fun getAppIcon(icon: Drawable): AppIcon {
         val adaptive = icon as? AdaptiveIconDrawable


### PR DESCRIPTION
## 概要
AppUtils.getAppIconでクラッシュが発生し、アプリが起動できないバグが発生していたためそのバグの修正

## 実施Issue
#213 

## 原因と対処
Nullエラーでアプリが落ちていた。そのため、AppUtils.getAppIconできちんとNullチェックをするように変更することでクラッシュが発生しないように変更。
```kt
    private fun getAppIcon(icon: Drawable): AppIcon {
        val adaptive = icon as? AdaptiveIconDrawable
        val foregroundIcon: Drawable? = adaptive?.foreground
        val backgroundIcon: Drawable? = adaptive?.background

        return if (foregroundIcon != null) {
            AppIcon(
                foregroundIcon = foregroundIcon,
                backgroundIcon = backgroundIcon,
            )
        } else {
            AppIcon(
                foregroundIcon = icon,
                backgroundIcon = null,
            )
        }
    }
```