### PR TITLE
[Bug]: 同時タップすると画面遷移がおかしくなる

### DIFF
--- a/app/src/main/kotlin/io/github/kei_1111/withmo/MainActivity.kt
+++ b/app/src/main/kotlin/io/github/kei_1111/withmo/MainActivity.kt
@@ -33,6 +33,7 @@ import io.github.kei_1111.withmo.core.domain.usecase.GetThemeSettingsUseCase
 import io.github.kei_1111.withmo.core.model.user_settings.ThemeSettings
 import io.github.kei_1111.withmo.core.model.user_settings.ThemeType
 import io.github.kei_1111.withmo.core.ui.AppWidgetHostsProvider
+import io.github.kei_1111.withmo.core.ui.ClickBlockerProvider
 import io.github.kei_1111.withmo.core.ui.CurrentTimeProvider
 import io.github.kei_1111.withmo.core.ui.LocalCurrentTime
 import io.github.kei_1111.withmo.core.util.AppUtils
@@ -162,13 +163,15 @@ class MainActivity : ComponentActivity() {
                         }
                     }
 
-                    WithmoTheme(
-                        themeType = themeSettings.themeType,
-                    ) {
-                        viewModel.startScreen?.let {
-                            App(
-                                startScreen = it,
-                            )
+                    ClickBlockerProvider {
+                        WithmoTheme(
+                            themeType = themeSettings.themeType,
+                        ) {
+                            viewModel.startScreen?.let {
+                                App(
+                                    startScreen = it,
+                                )
+                            }
                         }
                     }
                 }

--- a/build-logic/convention/src/main/kotlin/AndroidFeaturePlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidFeaturePlugin.kt
@@ -17,6 +17,7 @@ class AndroidFeaturePlugin : Plugin<Project> {
                 implementation(project(":core:domain"))
                 implementation(project(":core:featurebase"))
                 implementation(project(":core:model"))
+                implementation(project(":core:ui"))
                 implementation(project(":core:util"))
 
                 implementation(libs.findLibrary("androidx.activity.compose").get())

--- a/core/designsystem/src/main/kotlin/io/github/kei_1111/withmo/core/designsystem/component/AppItem.kt
+++ b/core/designsystem/src/main/kotlin/io/github/kei_1111/withmo/core/designsystem/component/AppItem.kt
@@ -1,10 +1,8 @@
 package io.github.kei_1111.withmo.core.designsystem.component
 
 import android.graphics.drawable.Drawable
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -29,6 +27,7 @@ import io.github.kei_1111.withmo.core.designsystem.component.theme.dimensions.We
 import io.github.kei_1111.withmo.core.designsystem.component.utils.withmoShadow
 import io.github.kei_1111.withmo.core.model.AppIcon
 import io.github.kei_1111.withmo.core.model.AppInfo
+import io.github.kei_1111.withmo.core.ui.modifier.safeClickable
 
 private const val AppItemLabelMaxLines = 1
 
@@ -85,7 +84,6 @@ fun AppItem(
 private const val AdaptiveIconScale = 1.5f
 
 @Suppress("LongMethod")
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun AppIcon(
     appIcon: AppIcon,
@@ -107,7 +105,7 @@ private fun AppIcon(
                         color = MaterialTheme.colorScheme.surface,
                         shape = appIconShape,
                     )
-                    .combinedClickable(
+                    .safeClickable(
                         onClick = onClick,
                         onLongClick = onLongClick,
                     ),
@@ -138,7 +136,7 @@ private fun AppIcon(
                         color = Color.White,
                         shape = CircleShape,
                     )
-                    .combinedClickable(
+                    .safeClickable(
                         onClick = onClick,
                         onLongClick = onLongClick,
                     ),

--- a/core/designsystem/src/main/kotlin/io/github/kei_1111/withmo/core/designsystem/component/WithmoIconButton.kt
+++ b/core/designsystem/src/main/kotlin/io/github/kei_1111/withmo/core/designsystem/component/WithmoIconButton.kt
@@ -1,7 +1,6 @@
 package io.github.kei_1111.withmo.core.designsystem.component
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
@@ -9,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import io.github.kei_1111.withmo.core.designsystem.component.utils.withmoShadow
+import io.github.kei_1111.withmo.core.ui.modifier.safeClickable
 
 @Composable
 fun WithmoIconButton(
@@ -25,7 +25,7 @@ fun WithmoIconButton(
                 color = MaterialTheme.colorScheme.surface,
                 shape = CircleShape,
             )
-            .clickable { onClick() },
+            .safeClickable { onClick() },
         contentAlignment = Alignment.Center,
     ) {
         content()

--- a/core/designsystem/src/main/kotlin/io/github/kei_1111/withmo/core/designsystem/component/WithmoSettingItemWithRadioButton.kt
+++ b/core/designsystem/src/main/kotlin/io/github/kei_1111/withmo/core/designsystem/component/WithmoSettingItemWithRadioButton.kt
@@ -1,6 +1,5 @@
 package io.github.kei_1111.withmo.core.designsystem.component
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
@@ -10,6 +9,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import io.github.kei_1111.withmo.core.designsystem.component.theme.dimensions.Paddings
 import io.github.kei_1111.withmo.core.designsystem.component.theme.dimensions.Weights
+import io.github.kei_1111.withmo.core.ui.LocalClickBlocker
+import io.github.kei_1111.withmo.core.ui.modifier.safeClickable
 
 // RadioButtonを用いて設定項目を作りたいときに使う
 // 設定項目はTextだけではないため、itemを@Composableで受け取るようにした
@@ -22,9 +23,11 @@ fun WithmoSettingItemWithRadioButton(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
 ) {
+    val clickBlocker = LocalClickBlocker.current
+
     Row(
         modifier = modifier
-            .clickable { onClick() }
+            .safeClickable { onClick() }
             .padding(horizontal = Paddings.Medium),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -32,7 +35,7 @@ fun WithmoSettingItemWithRadioButton(
         Spacer(modifier = Modifier.weight(Weights.Medium))
         RadioButton(
             selected = selected,
-            onClick = onClick,
+            onClick = { if (clickBlocker.tryClick()) onClick() },
             enabled = enabled,
         )
     }

--- a/core/designsystem/src/main/kotlin/io/github/kei_1111/withmo/core/designsystem/component/WithmoTopAppBar.kt
+++ b/core/designsystem/src/main/kotlin/io/github/kei_1111/withmo/core/designsystem/component/WithmoTopAppBar.kt
@@ -1,6 +1,5 @@
 package io.github.kei_1111.withmo.core.designsystem.component
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
@@ -21,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import io.github.kei_1111.withmo.core.designsystem.component.theme.dimensions.Paddings
 import io.github.kei_1111.withmo.core.designsystem.component.theme.dimensions.ShadowElevations
+import io.github.kei_1111.withmo.core.ui.modifier.safeClickable
 
 private val TopAppBarHeight = 64.dp
 
@@ -51,7 +51,7 @@ fun WithmoTopAppBar(
                     imageVector = Icons.Rounded.ArrowBackIosNew,
                     contentDescription = "Back",
                     tint = MaterialTheme.colorScheme.onSurface,
-                    modifier = Modifier.clickable { navigateBack() },
+                    modifier = Modifier.safeClickable { navigateBack() },
                 )
             }
             navigateClose?.let {
@@ -59,7 +59,7 @@ fun WithmoTopAppBar(
                     imageVector = Icons.Rounded.Close,
                     contentDescription = "Close",
                     tint = MaterialTheme.colorScheme.onSurface,
-                    modifier = Modifier.clickable { navigateClose() },
+                    modifier = Modifier.safeClickable { navigateClose() },
                 )
             }
             Box(

--- a/core/designsystem/src/main/kotlin/io/github/kei_1111/withmo/core/designsystem/component/favorite_settings/FavoriteAppSelectorItem.kt
+++ b/core/designsystem/src/main/kotlin/io/github/kei_1111/withmo/core/designsystem/component/favorite_settings/FavoriteAppSelectorItem.kt
@@ -35,7 +35,7 @@ fun FavoriteAppSelectorItem(
     ) {
         AppItem(
             appInfo = appInfo,
-            modifier = getFavoriteAppSelectorItemModifier(
+            modifier = GetFavoriteAppSelectorItemModifier(
                 isSelected = isSelected,
                 addSelectedAppList = addSelectedAppList,
                 removeSelectedAppList = removeSelectedAppList,
@@ -50,7 +50,7 @@ fun FavoriteAppSelectorItem(
 private val BorderWidth = 1.dp
 
 @Composable
-fun getFavoriteAppSelectorItemModifier(
+fun GetFavoriteAppSelectorItemModifier(
     isSelected: Boolean,
     addSelectedAppList: () -> Unit,
     removeSelectedAppList: () -> Unit,

--- a/core/designsystem/src/main/kotlin/io/github/kei_1111/withmo/core/designsystem/component/favorite_settings/FavoriteAppSelectorItem.kt
+++ b/core/designsystem/src/main/kotlin/io/github/kei_1111/withmo/core/designsystem/component/favorite_settings/FavoriteAppSelectorItem.kt
@@ -2,7 +2,6 @@ package io.github.kei_1111.withmo.core.designsystem.component.favorite_settings
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
@@ -17,6 +16,7 @@ import androidx.compose.ui.unit.dp
 import io.github.kei_1111.withmo.core.designsystem.component.AppItem
 import io.github.kei_1111.withmo.core.designsystem.component.theme.dimensions.Paddings
 import io.github.kei_1111.withmo.core.model.AppInfo
+import io.github.kei_1111.withmo.core.ui.modifier.safeClickable
 
 @Composable
 fun FavoriteAppSelectorItem(
@@ -59,7 +59,7 @@ fun getFavoriteAppSelectorItemModifier(
     return if (isSelected) {
         Modifier
             .clip(MaterialTheme.shapes.medium)
-            .clickable { removeSelectedAppList() }
+            .safeClickable { removeSelectedAppList() }
             .border(
                 BorderWidth,
                 MaterialTheme.colorScheme.primary,
@@ -70,7 +70,7 @@ fun getFavoriteAppSelectorItemModifier(
     } else {
         Modifier
             .clip(MaterialTheme.shapes.medium)
-            .clickable { addSelectedAppList() }
+            .safeClickable { addSelectedAppList() }
             .padding(Paddings.ExtraSmall)
     }
 }

--- a/core/designsystem/src/main/kotlin/io/github/kei_1111/withmo/core/designsystem/component/favorite_settings/FavoriteAppSelectorItem.kt
+++ b/core/designsystem/src/main/kotlin/io/github/kei_1111/withmo/core/designsystem/component/favorite_settings/FavoriteAppSelectorItem.kt
@@ -35,7 +35,7 @@ fun FavoriteAppSelectorItem(
     ) {
         AppItem(
             appInfo = appInfo,
-            modifier = GetFavoriteAppSelectorItemModifier(
+            modifier = getFavoriteAppSelectorItemModifier(
                 isSelected = isSelected,
                 addSelectedAppList = addSelectedAppList,
                 removeSelectedAppList = removeSelectedAppList,
@@ -50,7 +50,7 @@ fun FavoriteAppSelectorItem(
 private val BorderWidth = 1.dp
 
 @Composable
-fun GetFavoriteAppSelectorItemModifier(
+fun getFavoriteAppSelectorItemModifier(
     isSelected: Boolean,
     addSelectedAppList: () -> Unit,
     removeSelectedAppList: () -> Unit,

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -9,6 +9,7 @@ android {
 dependencies {
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.material3)
     implementation(projects.core.common)
     implementation(projects.core.model)
     implementation(projects.core.util)

--- a/core/ui/src/main/kotlin/io/github/kei_1111/withmo/core/ui/ClickBlockerProvider.kt
+++ b/core/ui/src/main/kotlin/io/github/kei_1111/withmo/core/ui/ClickBlockerProvider.kt
@@ -11,7 +11,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
 @Composable
 fun ClickBlockerProvider(
     delayMillis: Long = 200L,
-    content: @Composable () -> Unit
+    content: @Composable () -> Unit,
 ) {
     val blocker = remember(delayMillis) { ClickBlocker(delayMillis) }
     CompositionLocalProvider(LocalClickBlocker provides blocker) {
@@ -33,4 +33,3 @@ class ClickBlocker(private val delayMillis: Long) {
         }
     }
 }
-

--- a/core/ui/src/main/kotlin/io/github/kei_1111/withmo/core/ui/ClickBlockerProvider.kt
+++ b/core/ui/src/main/kotlin/io/github/kei_1111/withmo/core/ui/ClickBlockerProvider.kt
@@ -1,0 +1,36 @@
+@file:Suppress("MagicNumber")
+
+package io.github.kei_1111.withmo.core.ui
+
+import android.os.SystemClock
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
+
+@Composable
+fun ClickBlockerProvider(
+    delayMillis: Long = 200L,
+    content: @Composable () -> Unit
+) {
+    val blocker = remember(delayMillis) { ClickBlocker(delayMillis) }
+    CompositionLocalProvider(LocalClickBlocker provides blocker) {
+        content()
+    }
+}
+
+val LocalClickBlocker = staticCompositionLocalOf<ClickBlocker> { error("ClickBlocker not provided") }
+
+class ClickBlocker(private val delayMillis: Long) {
+    private var lastClick = 0L
+    fun tryClick(): Boolean {
+        val now = SystemClock.uptimeMillis()
+        return if (now - lastClick >= delayMillis) {
+            lastClick = now
+            true
+        } else {
+            false
+        }
+    }
+}
+

--- a/core/ui/src/main/kotlin/io/github/kei_1111/withmo/core/ui/modifier/SafeClickable.kt
+++ b/core/ui/src/main/kotlin/io/github/kei_1111/withmo/core/ui/modifier/SafeClickable.kt
@@ -1,3 +1,5 @@
+@file:Suppress("ModifierComposed")
+
 package io.github.kei_1111.withmo.core.ui.modifier
 
 import androidx.compose.foundation.ExperimentalFoundationApi

--- a/core/ui/src/main/kotlin/io/github/kei_1111/withmo/core/ui/modifier/SafeClickable.kt
+++ b/core/ui/src/main/kotlin/io/github/kei_1111/withmo/core/ui/modifier/SafeClickable.kt
@@ -1,0 +1,70 @@
+package io.github.kei_1111.withmo.core.ui.modifier
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Indication
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.semantics.Role
+import io.github.kei_1111.withmo.core.ui.LocalClickBlocker
+
+@OptIn(ExperimentalFoundationApi::class)
+fun Modifier.safeClickable(
+    enabled: Boolean = true,
+    onClickLabel: String? = null,
+    role: Role? = null,
+    onLongClickLabel: String? = null,
+    onLongClick: (() -> Unit)? = null,
+    onDoubleClick: (() -> Unit)? = null,
+    onClick: () -> Unit,
+): Modifier = composed {
+    val blocker = LocalClickBlocker.current
+    this.combinedClickable(
+        enabled = enabled,
+        onClickLabel = onClickLabel,
+        role = role,
+        onLongClickLabel = onLongClickLabel,
+        onLongClick = {
+            if (blocker.tryClick()) { onLongClick?.invoke() }
+        },
+        onDoubleClick = {
+            if (blocker.tryClick()) { onDoubleClick?.invoke() }
+        },
+        onClick = {
+            if (blocker.tryClick()) { onClick() }
+        },
+    )
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+fun Modifier.safeClickable(
+    interactionSource: MutableInteractionSource?,
+    indication: Indication?,
+    enabled: Boolean = true,
+    onClickLabel: String? = null,
+    role: Role? = null,
+    onLongClickLabel: String? = null,
+    onLongClick: (() -> Unit)? = null,
+    onDoubleClick: (() -> Unit)? = null,
+    onClick: () -> Unit,
+): Modifier = composed {
+    val blocker = LocalClickBlocker.current
+    this.combinedClickable(
+        interactionSource = interactionSource,
+        indication = indication,
+        enabled = enabled,
+        onClickLabel = onClickLabel,
+        role = role,
+        onLongClickLabel = onLongClickLabel,
+        onLongClick = {
+            if (blocker.tryClick()) { onLongClick?.invoke() }
+        },
+        onDoubleClick = {
+            if (blocker.tryClick()) { onDoubleClick?.invoke() }
+        },
+        onClick = {
+            if (blocker.tryClick()) { onClick() }
+        },
+    )
+}

--- a/feature/home/src/main/kotlin/io/github/kei_1111/withmo/feature/home/component/WidgetListSheet.kt
+++ b/feature/home/src/main/kotlin/io/github/kei_1111/withmo/feature/home/component/WidgetListSheet.kt
@@ -5,7 +5,6 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -45,6 +44,7 @@ import io.github.kei_1111.withmo.core.designsystem.component.theme.dimensions.Ic
 import io.github.kei_1111.withmo.core.designsystem.component.theme.dimensions.Paddings
 import io.github.kei_1111.withmo.core.designsystem.component.theme.dimensions.Weights
 import io.github.kei_1111.withmo.core.ui.LocalAppWidgetManager
+import io.github.kei_1111.withmo.core.ui.modifier.safeClickable
 import io.github.kei_1111.withmo.core.util.WidgetUtils
 import io.github.kei_1111.withmo.feature.home.HomeAction
 import io.github.kei_1111.withmo.feature.home.HomeScreenDimensions
@@ -128,7 +128,7 @@ private fun WidgetContainer(
                 modifier = Modifier
                     .height(CommonDimensions.SettingItemHeight)
                     .fillMaxWidth()
-                    .clickable { expanded = !expanded }
+                    .safeClickable { expanded = !expanded }
                     .padding(horizontal = Paddings.Medium),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
@@ -194,7 +194,7 @@ private fun WidgetItem(
 
     Column(
         modifier = modifier
-            .clickable { selectWidget(widgetInfo) },
+            .safeClickable { selectWidget(widgetInfo) },
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         if (previewDrawable != null) {

--- a/feature/onboarding/src/main/kotlin/io/github/kei_1111/withmo/feature/onboarding/component/contents/SelectDisplayModelContent.kt
+++ b/feature/onboarding/src/main/kotlin/io/github/kei_1111/withmo/feature/onboarding/component/contents/SelectDisplayModelContent.kt
@@ -5,7 +5,6 @@ import androidx.activity.compose.BackHandler
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -42,6 +41,7 @@ import io.github.kei_1111.withmo.core.designsystem.component.WithmoTopAppBar
 import io.github.kei_1111.withmo.core.designsystem.component.theme.dimensions.BadgeSizes
 import io.github.kei_1111.withmo.core.designsystem.component.theme.dimensions.Paddings
 import io.github.kei_1111.withmo.core.designsystem.component.theme.dimensions.Weights
+import io.github.kei_1111.withmo.core.ui.modifier.safeClickable
 import io.github.kei_1111.withmo.feature.onboarding.OnboardingAction
 import io.github.kei_1111.withmo.feature.onboarding.OnboardingScreenDimensions
 import io.github.kei_1111.withmo.feature.onboarding.OnboardingState
@@ -110,7 +110,7 @@ private fun SelectDisplayModelArea(
                 shape = MaterialTheme.shapes.medium,
                 width = OnboardingScreenDimensions.BorderWidth,
             )
-            .clickable { onClick() }
+            .safeClickable { onClick() }
     } else {
         modifier
             .size(OnboardingScreenDimensions.SelectDisplayModelAreaSize)
@@ -120,7 +120,7 @@ private fun SelectDisplayModelArea(
                 strokeWidth = OnboardingScreenDimensions.BorderWidth,
                 gapLength = OnboardingScreenDimensions.SelectDisplayModelAreaGapLength,
             )
-            .clickable { onClick() }
+            .safeClickable { onClick() }
     }
 
     Surface(

--- a/feature/setting/src/main/kotlin/io/github/kei_1111/withmo/feature/setting/root/component/SettingsScreenContent.kt
+++ b/feature/setting/src/main/kotlin/io/github/kei_1111/withmo/feature/setting/root/component/SettingsScreenContent.kt
@@ -1,6 +1,5 @@
 package io.github.kei_1111.withmo.feature.setting.root.component
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -37,6 +36,7 @@ import io.github.kei_1111.withmo.core.designsystem.component.theme.dimensions.Co
 import io.github.kei_1111.withmo.core.designsystem.component.theme.dimensions.IconSizes
 import io.github.kei_1111.withmo.core.designsystem.component.theme.dimensions.Paddings
 import io.github.kei_1111.withmo.core.designsystem.component.theme.dimensions.Weights
+import io.github.kei_1111.withmo.core.ui.modifier.safeClickable
 import io.github.kei_1111.withmo.feature.setting.root.SettingsAction
 import io.github.kei_1111.withmo.feature.setting.root.SettingsState
 
@@ -281,7 +281,7 @@ private fun SettingItem(
     Row(
         modifier = modifier
             .height(CommonDimensions.SettingItemHeight)
-            .clickable { onClick() }
+            .safeClickable { onClick() }
             .padding(horizontal = Paddings.Medium),
         verticalAlignment = Alignment.CenterVertically,
     ) {


### PR DESCRIPTION
## 概要
同時タップすると画面遷移がおかしくなっていたため、同時タップに加え、多重クリックにも対応した`safeClickable`を作成し、実装を置き換え

## 実施Issue
#210 

<!-- 以下は、条件に当てはまった際に使用 -->
<!-- バグの修正の際にのみ使用 -->
## 原因と対処
同時タップすることで、ナビゲーションがそれぞれ評価され、画面遷移が2度起こるということが発生していた。そのため、同時タップできないような仕組みを作成し、同時タップ問題に対処した。