### PR TITLE
[Fix]: アプリをタスクキルするとUnity画面が映らなくなるバグの修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,4 +152,5 @@ abstract class BaseViewModel<S : State, A : Action, E : Effect> : ViewModel() {
 - **コミットメッセージ**: `<type>: <description>` 形式で日本語、過去形で記述
 - **ブランチ命名**: `<type>/#<issue-number>` 形式（例：`feature/#225`）
 - **Issue/PRタイトル**: `[<Type>]: <タイトル>` 形式で統一
+- **プルリクエスト**: PRテンプレートは `.github/PULL_REQUEST_TEMPLATE.md` を参照
 - **開発フロー**: Issue作成 → ブランチ作成 → 開発 → PR作成 → レビュー → マージ

--- a/app/src/main/kotlin/io/github/kei_1111/withmo/MainActivity.kt
+++ b/app/src/main/kotlin/io/github/kei_1111/withmo/MainActivity.kt
@@ -112,7 +112,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
-        UnityManager.init(this)
+        UnityManager.init(this.applicationContext)
 
         observeModelFilePath()
         observeThemeSettings()


### PR DESCRIPTION
## 概要

アプリをタスクキルした際にUnity画面が映らなくなる問題を修正しました。UnityManagerの初期化時に`this`の代わりに`applicationContext`を渡すことで、Activityのライフサイクルに依存しない安定したコンテキストを使用します。

## 実施Issue

Fixes #234

## 原因と対処

**原因**: UnityManagerの初期化時に`this`（MainActivity）を渡していたため、アプリがタスクキルされた際にActivityが破棄されてUnityが正常に動作しなくなっていました。

**対処**: `this.applicationContext`を渡すことで、アプリケーションレベルのコンテキストを使用し、Activityのライフサイクルに依存しない安定したUnity動作を実現しました。

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>