### PR TITLE
[Refactor]: detektを並列で走らせるように変更

### DIFF
--- a/build-logic/convention/src/main/kotlin/DetektPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/DetektPlugin.kt
@@ -24,6 +24,8 @@ class DetektPlugin() : Plugin<Project> {
 
             tasks.withType<Detekt>().configureEach {
                 jvmTarget = "17"
+                // タスクの並列実行を促進
+                outputs.cacheIf { true }
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,9 @@
-import io.gitlab.arturbosch.detekt.Detekt
-
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.compose.compiler) apply false
-    alias(libs.plugins.detekt)
+    alias(libs.plugins.detekt) apply false
     alias(libs.plugins.firebase.crashlytics) apply false
     alias(libs.plugins.google.services) apply false
     alias(libs.plugins.hilt) apply false
@@ -20,28 +18,4 @@ plugins {
     alias(libs.plugins.withmo.android.library) apply false
     alias(libs.plugins.withmo.detekt) apply false
     alias(libs.plugins.withmo.hilt) apply false
-}
-
-val detektFormatting = libs.detekt.formatting
-val detektCompose = libs.detekt.compose
-
-subprojects {
-    apply(plugin = "io.gitlab.arturbosch.detekt")
-
-    dependencies {
-        detektPlugins(detektFormatting)
-        detektPlugins(detektCompose)
-    }
-
-    detekt {
-        config.setFrom("$rootDir/config/detekt/detekt.yml")
-        buildUponDefaultConfig = true
-
-        source.setFrom(files("src"))
-        autoCorrect = true
-    }
-
-    tasks.withType<Detekt>().configureEach {
-        jvmTarget = "17"
-    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,9 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+org.gradle.parallel=true
+org.gradle.configureondemand=true
+org.gradle.caching=true
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn


### PR DESCRIPTION
## 概要

detektの実行を並列化し、全モジュールで同時にdetektが実行されるように変更しました。これにより、エラーがあっても全モジュールの解析が完了し、すべてのエラーを一度に確認できるようになります。

## 実施Issue

Fixes #236

## 原因と対処

**原因**: 従来はdetektが各モジュールで順次実行されており、エラーが発生すると後続モジュールの解析が停止していました。

**対処**: 以下の変更により並列実行を実現しました：

### 1. Gradle並列実行の有効化
- `gradle.properties`で`org.gradle.parallel=true`を有効化
- `org.gradle.configureondemand=true`と`org.gradle.caching=true`を追加してパフォーマンスを向上

### 2. 重複設定の削除
- ルート`build.gradle.kts`の`subprojects`ブロック内detekt設定を削除
- 各モジュールの`DetektPlugin`で統一的に管理するため重複を解消

### 3. DetektPluginの最適化
- `outputs.cacheIf { true }`を追加してタスクキャッシュを有効化
- 各モジュールのdetektタスクが独立して並列実行されるよう最適化

## 効果

- **実行時間短縮**: 複数モジュールが同時に解析される
- **エラー確認効率**: 全モジュールのエラーを一度に確認可能
- **開発体験向上**: エラー修正のサイクル時間が短縮

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>